### PR TITLE
chore: migrate to sypl v2 (ES module + AnyMaxLevel replacement)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
 )
 
 var (

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -23,12 +23,12 @@ import (
 	"github.com/thalesfsp/configurer/util"
 	"github.com/thalesfsp/customerror"
 	"github.com/thalesfsp/mole/core"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/flag"
-	"github.com/thalesfsp/sypl/level"
-	"github.com/thalesfsp/sypl/output"
-	"github.com/thalesfsp/sypl/processor"
+	"github.com/thalesfsp/sypl/es/v2"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/flag"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/processor"
 )
 
 // Regex pattern for .env extensions (.env, .env.local, .env.prod, etc.)
@@ -233,11 +233,11 @@ func runCommand(
 			esConfig.Addresses = []string{"http://localhost:9200"}
 		}
 
-		esOutput := output.ElasticSearchWithDynamicIndex(
+		esOutput := es.OutputWithDynamicIndex(
 			func() string {
 				return fmt.Sprintf("%s-%s", esConfig.Index, time.Now().Format("2006-01"))
 			},
-			output.ElasticSearchConfig{
+			es.Config{
 				Addresses:    esConfig.Addresses,
 				APIKey:       esConfig.APIKey,
 				CloudID:      esConfig.CloudID,

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/thalesfsp/customerror v1.2.9
 	github.com/thalesfsp/godotenv v1.4.2
 	github.com/thalesfsp/httpclient v1.2.7
+	github.com/thalesfsp/sypl/es/v2 v2.0.0
+	github.com/thalesfsp/sypl/v2 v2.0.0
 	github.com/thalesfsp/validation v0.0.3
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -115,7 +117,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/thalesfsp/mole v1.0.2
-	github.com/thalesfsp/sypl v1.19.20
+	github.com/thalesfsp/sypl v1.19.20 // indirect
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,10 @@ github.com/thalesfsp/status v1.0.22 h1:XAajv9dp5piEIOpgaqld9RPPPEi+lbCiGHWqElmqs
 github.com/thalesfsp/status v1.0.22/go.mod h1:ZwlaaU4tPETPq/wf3bsS/sVqSQpMUPMK7iTqkSSJqVY=
 github.com/thalesfsp/sypl v1.19.20 h1:FcKm7x5Xx7k/5UPXysjELMQnpQ9x5xc9R6VzMKFH+EY=
 github.com/thalesfsp/sypl v1.19.20/go.mod h1:poTPF9XvuMAcZ1qnyLyUJhP9ivAyrODoKFMuDc/b6AU=
+github.com/thalesfsp/sypl/es/v2 v2.0.0 h1:EEVFFEL9cabgQte4qiQOFq2j1xmdnl9+zT/3wrL0ZWE=
+github.com/thalesfsp/sypl/es/v2 v2.0.0/go.mod h1:KF4tD1Yq09Nhd8qSB/C5kpgfPiHlm+Gdk5vtIjRBmlY=
+github.com/thalesfsp/sypl/v2 v2.0.0 h1:sG8R5DPKpsbq0pF+jSlEy1XNYIrhTUbfwA1duLmq5/8=
+github.com/thalesfsp/sypl/v2 v2.0.0/go.mod h1:RCM1KBOet35pLWc6VPixSPPa5neyxaGJHGeRT5CEczY=
 github.com/thalesfsp/validation v0.0.3 h1:iXWXZLALIGUKJSxAeDt40kxUyzjeHeHc86f9fP9vin4=
 github.com/thalesfsp/validation v0.0.3/go.mod h1:0jwfQpbuzVJgVSPoiDJ7KCT76CLdMq4R++InC353SZ8=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -5,9 +5,9 @@
 package logging
 
 import (
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
-	"github.com/thalesfsp/sypl/processor"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/processor"
 )
 
 //////

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -5,8 +5,23 @@ import (
 	"os"
 
 	"github.com/thalesfsp/customerror"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/shared"
 )
+
+// anyMaxLevel reports whether any output's maxLevel equals target, or the
+// SYPL_LEVEL env var names it — v1 Sypl.AnyMaxLevel semantics. Replacement
+// for the v2-removed Sypl.AnyMaxLevel, per sypl's MIGRATION-V2.md.
+func anyMaxLevel(l *sypl.Sypl, target level.Level) bool {
+	for _, ml := range l.GetMaxLevel() { // map[outputName]level.Level
+		if ml == target {
+			return true
+		}
+	}
+
+	return os.Getenv(shared.LevelEnvVar) == target.String()
+}
 
 // ExportToEnvVar exports the given key and value to the environment.
 //
@@ -33,9 +48,9 @@ func ExportToEnvVar(p IProvider, key string, value interface{}) (string, error) 
 		)
 	}
 
-	if p.GetLogger().AnyMaxLevel(level.Debug) {
+	if anyMaxLevel(p.GetLogger().Sypl, level.Debug) {
 		p.GetLogger().Debuglnf("Exported key %s", key)
-	} else if p.GetLogger().AnyMaxLevel(level.Trace) {
+	} else if anyMaxLevel(p.GetLogger().Sypl, level.Trace) {
 		p.GetLogger().Tracelnf("Exported key %s with value %s", key, finalValue)
 	}
 

--- a/provider/utils_test.go
+++ b/provider/utils_test.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"io"
+	"testing"
+
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/output"
+	"github.com/thalesfsp/sypl/v2/shared"
+)
+
+// newLoggerWithMaxLevels builds a logger with one discard output per level.
+func newLoggerWithMaxLevels(levels ...level.Level) *sypl.Sypl {
+	l := sypl.New("test")
+
+	for i, lvl := range levels {
+		l.AddOutputs(output.New("out-"+string(rune('a'+i)), lvl, io.Discard))
+	}
+
+	return l
+}
+
+// TestAnyMaxLevel proves the anyMaxLevel helper preserves the removed v1
+// Sypl.AnyMaxLevel semantics used by the ExportToEnvVar guard: true when
+// some output's maxLevel EQUALS the target (or SYPL_LEVEL names it), false
+// otherwise.
+func TestAnyMaxLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputCaps  []level.Level
+		envLevel    string
+		wantDebug   bool
+		wantTrace   bool
+		description string
+	}{
+		{
+			name:        "output capped at Debug",
+			outputCaps:  []level.Level{level.Debug},
+			wantDebug:   true,
+			wantTrace:   false,
+			description: "guard takes the Debug branch, as in v1",
+		},
+		{
+			name:        "output capped at Trace",
+			outputCaps:  []level.Level{level.Trace},
+			wantDebug:   false,
+			wantTrace:   true,
+			description: "guard takes the Trace branch (logs the value), as in v1",
+		},
+		{
+			name:        "output capped at Info",
+			outputCaps:  []level.Level{level.Info},
+			wantDebug:   false,
+			wantTrace:   false,
+			description: "neither branch fires, as in v1",
+		},
+		{
+			name:        "no outputs",
+			outputCaps:  nil,
+			wantDebug:   false,
+			wantTrace:   false,
+			description: "neither branch fires, as in v1",
+		},
+		{
+			name:        "mixed outputs Info+Debug",
+			outputCaps:  []level.Level{level.Info, level.Debug},
+			wantDebug:   true,
+			wantTrace:   false,
+			description: "any single matching output is enough, as in v1",
+		},
+		{
+			name:        "SYPL_LEVEL env var names debug",
+			outputCaps:  []level.Level{level.Info},
+			envLevel:    level.Debug.String(),
+			wantDebug:   true,
+			wantTrace:   false,
+			description: "v1 env-var fallback preserved",
+		},
+		{
+			name:        "SYPL_LEVEL env var names trace",
+			outputCaps:  []level.Level{level.Info},
+			envLevel:    level.Trace.String(),
+			wantDebug:   false,
+			wantTrace:   true,
+			description: "v1 env-var fallback preserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv also isolates: unset means empty for this subtest.
+			t.Setenv(shared.LevelEnvVar, tt.envLevel)
+
+			l := newLoggerWithMaxLevels(tt.outputCaps...)
+
+			if got := anyMaxLevel(l, level.Debug); got != tt.wantDebug {
+				t.Errorf(
+					"anyMaxLevel(l, Debug) = %v, want %v (%s)",
+					got, tt.wantDebug, tt.description,
+				)
+			}
+
+			if got := anyMaxLevel(l, level.Trace); got != tt.wantTrace {
+				t.Errorf(
+					"anyMaxLevel(l, Trace) = %v, want %v (%s)",
+					got, tt.wantTrace, tt.description,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Migrates configurer to sypl v2 per `MIGRATION-V2.md`. This is the only repo in the fleet calling removed v1 API, plus it uses the ES dynamic-index output.

## Module bumps

| Module | Before | After |
|---|---|---|
| `github.com/thalesfsp/sypl` | `v1.19.20` (direct) | dropped (remains **indirect** via `concurrentloop@v1.4.4`, which imports v1 internally — different import path, coexists safely) |
| `github.com/thalesfsp/sypl/v2` | — | `v2.0.0` |
| `github.com/thalesfsp/sypl/es/v2` | — | `v2.0.0` (ES was isolated into a nested submodule in v2 so the core module no longer pulls `go-elasticsearch`) |

## Symbol mapping

| v1 | v2 | Where |
|---|---|---|
| `github.com/thalesfsp/sypl` (+ `fields`, `flag`, `level`, `processor` subpackages) | same path with `/v2/` inserted | `cmd/utils.go`, `cmd/root.go`, `internal/logging/logging.go`, `provider/utils.go` |
| `output.ElasticSearchWithDynamicIndex(...)` | `es.OutputWithDynamicIndex(...)` — identical signature | `cmd/utils.go` |
| `output.ElasticSearchConfig` | `es.Config` | `cmd/utils.go` |
| `Sypl.AnyMaxLevel(l)` (removed in v2) | local `anyMaxLevel(l, target)` helper — the exact drop-in from `MIGRATION-V2.md` | `provider/utils.go` |

Note: `cmd/utils.go`'s `ElasticSearchConfig` type (line ~114) is configurer's **own** JSON-settings type and is untouched; only the sypl-owned `output.ElasticSearchConfig` literal at the construction site changed to `es.Config`.

## AnyMaxLevel before/after (behavioral seam)

Before (v1):

```go
if p.GetLogger().AnyMaxLevel(level.Debug) {
	p.GetLogger().Debuglnf("Exported key %s", key)
} else if p.GetLogger().AnyMaxLevel(level.Trace) {
	p.GetLogger().Tracelnf("Exported key %s with value %s", key, finalValue)
}
```

After (v2):

```go
if anyMaxLevel(p.GetLogger().Sypl, level.Debug) {
	p.GetLogger().Debuglnf("Exported key %s", key)
} else if anyMaxLevel(p.GetLogger().Sypl, level.Trace) {
	p.GetLogger().Tracelnf("Exported key %s with value %s", key, finalValue)
}

// anyMaxLevel reports whether any output's maxLevel equals target, or the
// SYPL_LEVEL env var names it — v1 Sypl.AnyMaxLevel semantics.
func anyMaxLevel(l *sypl.Sypl, target level.Level) bool {
	for _, ml := range l.GetMaxLevel() { // map[outputName]level.Level
		if ml == target {
			return true
		}
	}
	return os.Getenv(shared.LevelEnvVar) == target.String()
}
```

**Why the exact drop-in (`==`) and not the guide's idiomatic `>=` form:** this call site is an `if / else if` with *different bodies* — a Debug-capped logger logs the key only; a Trace-capped logger logs the key **and the value**. v1 `AnyMaxLevel` matches a cap that *equals* the level (verified against the v1.19.20 source). Under the idiomatic `>=` form, a Trace-capped output would satisfy the Debug check first and silently switch the Trace branch (value included) to the Debug branch (value omitted). The `==` drop-in keeps branch selection bit-for-bit identical to v1, including the `SYPL_LEVEL` env-var fallback.

## Test evidence

New `provider/utils_test.go` (`TestAnyMaxLevel`, table-driven, run with `-race`) proves v1-equivalence:

| Logger state | `anyMaxLevel(Debug)` | `anyMaxLevel(Trace)` | Guard branch (v1-identical) |
|---|---|---|---|
| output capped at `Debug` | true | false | Debug (key only) |
| output capped at `Trace` | false | true | Trace (key + value) |
| output capped at `Info` | false | false | none |
| no outputs | false | false | none |
| outputs at `Info` + `Debug` | true | false | Debug |
| `SYPL_LEVEL=debug`, output at `Info` | true | false | Debug (env fallback) |
| `SYPL_LEVEL=trace`, output at `Info` | false | true | Trace (env fallback) |

Negative control: mutating the helper's `==` to `>=` fails exactly the Trace-capped case (`anyMaxLevel(l, Debug) = true, want false`) — the test fails for the right reason, then restored to green.

## Verification (all local, before push)

- `go build ./...` — OK
- `go vet ./...` — OK
- `make test` (full suite, `-short -race -cover ./...`) — Test OK
- `golangci-lint v2.5.0` (the exact CI-pinned version) with `.golangci.yml` — 0 issues

## Other v2 notes

- Level ordering (`Warn`/`Info` numeric swap): configurer has no numeric-level usage (`FromInt`/persisted ints); the ES output and `SetDefaultIoWriterLevel` are capped at `Info`, which under v2's conventional nesting now also admits `Warn` — strictly more correct visibility, no code change needed.
- Runtime ES output names (`GetName()`) are unchanged in v2, so `--log-outputs elasticsearch` behavior is unaffected.
