### PR TITLE
fix(awssm): unwrap double-encoded secrets; exit 0 on pure --dump

### DIFF
--- a/awssm/awssm.go
+++ b/awssm/awssm.go
@@ -92,9 +92,12 @@ func (a *AWSSM) Load(ctx context.Context, opts ...option.LoadKeyFunc) (map[strin
 			)
 		}
 
-		// Try to parse as JSON first, if it fails treat as plain string.
-		var secretData map[string]interface{}
-		if err := json.Unmarshal([]byte(*result.SecretString), &secretData); err != nil {
+		// Try to parse as a JSON object of key/value pairs, transparently
+		// unwrapping double-encoded secrets (a JSON string that itself contains
+		// a JSON object). If it is not a JSON object, treat the entire secret as
+		// a single plain-text value.
+		secretData, isJSONObject := parseSecretData(*result.SecretString)
+		if !isJSONObject {
 			// If it's not JSON, treat the entire secret as a single key-value pair.
 			// Use the secret name (last part after /) as the key.
 			key := secretName
@@ -139,6 +142,38 @@ func (a *AWSSM) Load(ctx context.Context, opts ...option.LoadKeyFunc) (map[strin
 	}
 
 	return finalValues, nil
+}
+
+// parseSecretData interprets a secret string as a JSON object of key/value
+// pairs. It transparently unwraps secrets stored double-encoded — a JSON string
+// that itself contains a JSON object, e.g. `"{\"KEY\":\"value\"}"` — which is a
+// common result of tooling that stores a JSON payload as a quoted string. It
+// returns the parsed map and true when the secret is (possibly nested) JSON
+// object, or (nil, false) when it should be treated as a single plain-text
+// value.
+func parseSecretData(secretString string) (map[string]interface{}, bool) {
+	s := secretString
+
+	// Each iteration either parses an object (done) or peels one layer of
+	// JSON-string wrapping. Bounded to avoid pathological inputs.
+	for range 4 {
+		var secretData map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &secretData); err == nil {
+			return secretData, true
+		}
+
+		// Not an object at this level: it may be a JSON-encoded string wrapping
+		// more JSON (double-encoded). Peel one layer and retry.
+		var inner string
+		if err := json.Unmarshal([]byte(s), &inner); err != nil {
+			// Neither an object nor a JSON string: genuine plain text.
+			return nil, false
+		}
+
+		s = inner
+	}
+
+	return nil, false
 }
 
 // Write stores a new secret in AWS Secrets Manager.

--- a/awssm/parse_test.go
+++ b/awssm/parse_test.go
@@ -1,0 +1,115 @@
+package awssm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// doubleEncode returns s wrapped as a JSON string literal, i.e. the form AWS
+// Secrets Manager returns when a JSON payload was stored as a quoted string
+// (double-encoded). For inner `{"K":"v"}` it yields `"{\"K\":\"v\"}"`.
+func doubleEncode(t *testing.T, s string) string {
+	t.Helper()
+
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("doubleEncode: %v", err)
+	}
+
+	return string(b)
+}
+
+func TestParseSecretData(t *testing.T) {
+	object := `{"APP_KEY":"base64:abc+/=","DB_HOST":"prod.rds.amazonaws.com"}`
+
+	tests := []struct {
+		name       string
+		input      string
+		wantOK     bool
+		wantKeys   map[string]string
+		wantLength int
+	}{
+		{
+			name:       "single-encoded JSON object",
+			input:      object,
+			wantOK:     true,
+			wantKeys:   map[string]string{"APP_KEY": "base64:abc+/=", "DB_HOST": "prod.rds.amazonaws.com"},
+			wantLength: 2,
+		},
+		{
+			name:       "double-encoded object (JSON string containing JSON) - the regression",
+			input:      doubleEncode(t, object),
+			wantOK:     true,
+			wantKeys:   map[string]string{"APP_KEY": "base64:abc+/=", "DB_HOST": "prod.rds.amazonaws.com"},
+			wantLength: 2,
+		},
+		{
+			name:       "triple-encoded object",
+			input:      doubleEncode(t, doubleEncode(t, object)),
+			wantOK:     true,
+			wantKeys:   map[string]string{"APP_KEY": "base64:abc+/="},
+			wantLength: 2,
+		},
+		{
+			name:   "empty JSON object",
+			input:  `{}`,
+			wantOK: true,
+		},
+		{
+			name:   "genuine plain text",
+			input:  "hunter2",
+			wantOK: false,
+		},
+		{
+			name:   "JSON string that is not an object",
+			input:  `"just a value"`,
+			wantOK: false,
+		},
+		{
+			name:   "JSON array is not a key/value object",
+			input:  `["a","b"]`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseSecretData(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("parseSecretData ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if tt.wantLength != 0 && len(got) != tt.wantLength {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLength)
+			}
+
+			for k, v := range tt.wantKeys {
+				if fmt := toString(got[k]); fmt != v {
+					t.Errorf("key %q = %q, want %q", k, fmt, v)
+				}
+			}
+		})
+	}
+}
+
+// TestParseSecretData_NegativeControl documents that the previous behaviour (a
+// single json.Unmarshal into a map) fails on double-encoded secrets — which is
+// exactly why they were mis-handled as a single plain-text value.
+func TestParseSecretData_NegativeControl(t *testing.T) {
+	double := doubleEncode(t, `{"APP_KEY":"v"}`)
+
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(double), &m); err == nil {
+		t.Fatalf("expected plain Unmarshal to FAIL on double-encoded input, but it succeeded: %v", m)
+	}
+
+	if _, ok := parseSecretData(double); !ok {
+		t.Fatalf("parseSecretData should recover the double-encoded object")
+	}
+}
+
+func toString(v interface{}) string {
+	s, _ := v.(string)
+
+	return s
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -407,6 +407,16 @@ func ConcurrentRunner(p provider.IProvider, cmds []string, args []string) {
 	if len(cmds) == 0 {
 		command, arguments := splitCmdFromArgs(args)
 
+		// Nothing to exec (e.g., a pure --dump/--override with no trailing
+		// command). The provider has already loaded and dumped its values, so
+		// exit successfully instead of failing with "exec: no command".
+		if command == "" {
+			// Wait for any output to be flushed.
+			time.Sleep(flushInterval)
+
+			os.Exit(0)
+		}
+
 		exitCode := runCommand(p, command, arguments, false)
 
 		// Wait for any output to be flushed.


### PR DESCRIPTION
## Problem
A production incident (RingBoost, 2026-07-16) traced to the awssm provider: secrets stored **double-encoded** — a JSON string that itself contains a JSON object, e.g. `"{\"APP_KEY\":\"v\"}"` — were mis-handled.

`Load()` did a single `json.Unmarshal(SecretString, &map[string]interface{})`. That fails on a double-encoded secret (it is a JSON *string*, not an object), so the code fell through to the plain-text branch and emitted **one** variable named after the secret (`production=<blob>`), dropping every real key. Downstream apps got an empty `APP_KEY` and 500'd on restart.

Separately, `l <provider> --dump <file>` with **no trailing command** exited `1` with `exec: no command` even though the dump succeeded — noisy and breaks `set -e` entrypoints.

## Fix
- `parseSecretData` transparently unwraps up to a few layers of JSON-string wrapping, so **single- and double-encoded** secrets both parse into separate vars. Genuine plain text / non-object JSON still fall through to the single-value path.
- `ConcurrentRunner` exits `0` when there is nothing to exec (pure `--dump`/`--override`).

## Tests
- `awssm/parse_test.go`: table-driven (single, double, triple-encoded, empty object, plain text, JSON string, JSON array) + a negative control asserting plain `Unmarshal` fails on double-encoded input while `parseSecretData` recovers it.
- Verified end-to-end against real AWS Secrets Manager: a double-encoded secret now dumps separate vars and exits 0.
- Full suite green; `go vet` clean.