### PR TITLE
fix(install): support Linux aarch64 in install.sh

### DIFF
--- a/resources/install.sh
+++ b/resources/install.sh
@@ -84,7 +84,7 @@ case $arch in
   x86_64)
     arch="amd64"
     ;;
-  arm64)
+  arm64 | aarch64)
     arch="arm64"
     ;;
   armv6l)


### PR DESCRIPTION
On Linux ARM64, `uname -m` returns `aarch64` (`arm64` is the macOS spelling). The installer arch case only handled `arm64`, so it aborted with `Unsupported architecture: aarch64` inside `linux/arm64` containers — even though `configurer_*_linux_arm64.tar.gz` is already published. Adds `aarch64` to the `arm64` case. Verified: patched script installs the arm64 binary cleanly in a `linux/arm64` container (unpatched aborts). Unblocks the RingBoost Graviton/ARM64 migration for every service that installs configurer.