### PR TITLE
fix(cmd): forward SIGTERM/SIGINT to the child instead of SIGKILL

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/kvz/logstreamer"
@@ -180,17 +181,9 @@ func runCommand(
 
 	// Signal handling setup
 	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt)
-
-	go func() {
-		<-stop
-
-		time.Sleep(shutdownTimeout)
-
-		c.Process.Kill()
-
-		handleCommandKill(p)
-	}()
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	childDone := make(chan struct{})
+	shutdownStarted := make(chan struct{})
 
 	//////
 	// Redirect output.
@@ -281,7 +274,7 @@ func runCommand(
 			// Flush every 1 second.
 			for {
 				select {
-				case <-stop:
+				case <-shutdownStarted:
 					return
 				default:
 					// Only if there is something to flush.
@@ -349,8 +342,36 @@ func runCommand(
 		}()
 	}
 
-	// Start command and wait it to finish.
-	if err := c.Run(); err != nil {
+	// Start command.
+	if err := c.Start(); err != nil {
+		cliLogger.Errorlnf("error running command: %s", err)
+
+		return 1
+	}
+
+	go func() {
+		s := <-stop
+		close(shutdownStarted)
+		c.Process.Signal(s)
+
+		timer := time.NewTimer(shutdownTimeout)
+		defer timer.Stop()
+
+		select {
+		case <-childDone:
+			return
+		case <-timer.C:
+			if err := c.Process.Kill(); err == nil {
+				handleCommandKill(p)
+			}
+		}
+	}()
+
+	// Wait for the command to finish.
+	err := c.Wait()
+	close(childDone)
+
+	if err != nil {
 		// If an error occurs, handle it appropriately.
 		// For example, log the error and return a non-zero status.
 		cliLogger.Errorlnf("error running command: %s", err)

--- a/cmd/utils_signal_test.go
+++ b/cmd/utils_signal_test.go
@@ -1,0 +1,217 @@
+//go:build unix
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const (
+	signalHelperEnv      = "CONFIGURER_SIGNAL_HELPER"
+	signalHelperReady    = "CONFIGURER_CHILD_READY"
+	signalHelperReceived = "CONFIGURER_CHILD_RECEIVED"
+)
+
+func TestRunCommandForwardsSIGTERM(t *testing.T) {
+	testRunCommandSignal(t, syscall.SIGTERM)
+}
+
+func TestRunCommandForwardsSIGINT(t *testing.T) {
+	testRunCommandSignal(t, os.Interrupt)
+}
+
+func TestRunCommandKillsChildAfterShutdownTimeout(t *testing.T) {
+	const timeout = 200 * time.Millisecond
+
+	started := time.Now()
+	output, err := runSignalHelper(t, syscall.SIGTERM, "ignore", timeout)
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("expected parent to exit non-zero after killing unresponsive child")
+	}
+
+	if !strings.Contains(output, signalHelperReady) {
+		t.Fatalf("child did not start: %s", output)
+	}
+
+	if elapsed < timeout {
+		t.Fatalf("child was killed before shutdown timeout: elapsed %s, timeout %s", elapsed, timeout)
+	}
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("parent hung after shutdown timeout: elapsed %s", elapsed)
+	}
+}
+
+func TestRunCommandSignalHelper(t *testing.T) {
+	if os.Getenv(signalHelperEnv) == "" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+
+	if len(args) < 4 {
+		t.Fatalf("missing helper arguments: %v", os.Args)
+	}
+
+	role, mode, timeoutString := args[1], args[2], args[3]
+
+	switch role {
+	case "parent":
+		timeout, err := time.ParseDuration(timeoutString)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shutdownTimeout = timeout
+		exitCode := runCommand(
+			nil,
+			os.Args[0],
+			[]string{
+				"-test.run=^TestRunCommandSignalHelper$",
+				"--",
+				"child",
+				mode,
+				timeoutString,
+			},
+			false,
+		)
+		os.Exit(exitCode)
+	case "child":
+		if mode == "ignore" {
+			signal.Ignore(os.Interrupt, syscall.SIGTERM)
+			fmt.Println(signalHelperReady)
+			select {}
+		}
+
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+		fmt.Println(signalHelperReady)
+		fmt.Printf("%s:%s\n", signalHelperReceived, <-signals)
+		os.Exit(0)
+	default:
+		t.Fatalf("unknown helper role %q", role)
+	}
+}
+
+func testRunCommandSignal(t *testing.T, s os.Signal) {
+	t.Helper()
+
+	output, err := runSignalHelper(t, s, "handle", 3*time.Second)
+	if err != nil {
+		t.Fatalf("parent exited with error: %v\n%s", err, output)
+	}
+
+	want := fmt.Sprintf("%s:%s", signalHelperReceived, s)
+	if !strings.Contains(output, want) {
+		t.Fatalf("child did not receive forwarded signal %s\noutput:\n%s", s, output)
+	}
+}
+
+func runSignalHelper(
+	t *testing.T,
+	s os.Signal,
+	mode string,
+	timeout time.Duration,
+) (string, error) {
+	t.Helper()
+
+	command := exec.Command(
+		os.Args[0],
+		"-test.run=^TestRunCommandSignalHelper$",
+		"--",
+		"parent",
+		mode,
+		timeout.String(),
+	)
+	command.Env = append(os.Environ(), signalHelperEnv+"=1")
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		lines     []string
+		linesLock sync.Mutex
+		ready     = make(chan struct{})
+		readyOnce sync.Once
+	)
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			linesLock.Lock()
+			lines = append(lines, line)
+			linesLock.Unlock()
+
+			if line == signalHelperReady {
+				readyOnce.Do(func() { close(ready) })
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		command.Wait()
+		t.Fatal("timed out waiting for child readiness")
+	}
+
+	if err := command.Process.Signal(s); err != nil {
+		syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		command.Wait()
+		t.Fatal(err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- command.Wait()
+	}()
+
+	var waitErr error
+	select {
+	case waitErr = <-waitDone:
+	case <-time.After(5 * time.Second):
+		syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		waitErr = <-waitDone
+	}
+
+	<-scanDone
+	linesLock.Lock()
+	output := strings.Join(lines, "\n")
+	linesLock.Unlock()
+
+	if stderr.Len() > 0 {
+		output += "\n" + stderr.String()
+	}
+
+	return output, waitErr
+}


### PR DESCRIPTION
configurer is used as a process wrapper across ~18 production services via `exec configurer ... -- <binary>`, which makes configurer the surviving container process (PID 1) and the application its child.

## The defect

`cmd/utils.go` registered only `os.Interrupt`, and hard-killed the child:

```go
signal.Notify(stop, os.Interrupt)        // SIGTERM never registered
go func() {
    <-stop
    time.Sleep(shutdownTimeout)
    c.Process.Kill()                     // SIGKILL — cannot be caught
    handleCommandKill(p)
}()
```

ECS, Kubernetes and Docker all send **SIGTERM**. Go terminated configurer immediately on it and forwarded nothing. And even on SIGINT the child got SIGKILL, so a child handler could not run under any signal. `grep -rn SIGTERM --include="*.go"` returned zero hits in the whole module.

## The fix

Register both signals; forward the signal actually received with `c.Process.Signal(s)`; wait for the child; escalate to `Kill()` only after `shutdownTimeout`. `c.Run()` becomes `c.Start()` + `c.Wait()` so the lifecycle can be managed, and the output flusher gets its own `shutdownStarted` channel because the signal goroutine now consumes from `stop`.

## Why it matters

A downstream Go service registered SIGTERM and its graceful-shutdown code never executed once. CloudWatch Logs Insights over `/ecs/production-uvs`, 90 days, **51,240,564 records scanned, zero matches** for shutdown/sigterm/draining/graceful.

On 2026-07-28 an importer was SIGKILLed mid-run during routine ECS host maintenance. It could not release its SQS message or mark its in-flight task failed, so a distributed lock stayed held and the queue message sat invisible for its full 6h visibility timeout. Four vendors were then blocked from retrying by their own orphaned records — a day-long data outage.

## Verification

- `go build ./...`, `go vet ./...` clean.
- Full suite green under `-race` across all 12 packages.
- New tests: SIGTERM forwarding, SIGINT forwarding, and SIGKILL escalation for a child that ignores the signal.
- **Negative control** — with the fix reverted, all three fail for the right reasons:
  - `TestRunCommandForwardsSIGTERM` → `parent exited with error: signal: terminated`
  - `TestRunCommandForwardsSIGINT` → `parent exited with error: exit status 1`
  - `TestRunCommandKillsChildAfterShutdownTimeout` → `parent hung after shutdown timeout: elapsed 5.04s`
- **Cross-repo proof**: a process-level test in the downstream service fails against released `v1.3.37` (`child never received SIGTERM from configurer parent within 3s`) and passes against this branch.

## Compatibility

Non-breaking; suitable for a patch release (v1.3.38). Behaviour only changes on shutdown, and only to give the child the grace period that `shutdownTimeout` always implied.