### PR TITLE
fix(provider): decide env var precedence by presence, not emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Backup strategy. When one provider fail, fallback to another.
 
+## [Unreleased]
+### Fixed
+- Env var precedence is now decided by PRESENCE instead of by emptiness. A
+  variable that is already set — even to the empty string — is preserved when
+  `override` is `false`. Previously `ExportToEnvVar` compared `os.Getenv(key)`
+  against `""`, so a variable set to an empty value was silently overwritten by
+  the provider value despite the caller asking for no override. This affects
+  every provider, since they all export through that helper.
+
+  **Migration:** if you relied on declaring a placeholder such as `KEY=` (e.g.
+  `docker run -e KEY=`, a Kubernetes `env` entry with `value: ""`, or a `.env`
+  placeholder) and expected configurer to fill it in, either unset the variable
+  instead of setting it empty, or enable `override` deliberately.
+
 ## [1.1.30] - 2023-03-16
 ### Changed
 - Behaves like `json` tag regarding non-exported and ignored fields.

--- a/awssm/awssm_unit_test.go
+++ b/awssm/awssm_unit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 )
 
@@ -687,7 +688,7 @@ func TestAWSSMLoadUnit(t *testing.T) {
 
 			for key := range tt.want {
 				if _, exists := tt.existingEnv[key]; !exists {
-					t.Setenv(key, "")
+					testenv.Unset(t, key)
 				}
 			}
 

--- a/awsssm/awsssm_unit_test.go
+++ b/awsssm/awsssm_unit_test.go
@@ -14,6 +14,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 )
 
@@ -459,7 +460,7 @@ func TestAWSSSMLoadByPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			httpClient, recorder := newFakeSSMHTTPClient(t, tt.responder)
 			for key, value := range tt.want {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 				if seededValue, ok := tt.seedEnvironment[key]; ok {
 					t.Setenv(key, seededValue)
 				}
@@ -608,7 +609,7 @@ func TestAWSSSMLoadByNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			httpClient, recorder := newFakeSSMHTTPClient(t, tt.responder)
 			for key := range tt.want {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 			}
 
 			awsssmProvider := newFakeAWSSSM(
@@ -681,8 +682,8 @@ func TestAWSSSMLoadCombinedSources(t *testing.T) {
 					return fakeSSMResponse{statusCode: http.StatusBadRequest}
 				}
 			})
-			t.Setenv("path-key", "")
-			t.Setenv("name-key", "")
+			testenv.Unset(t, "path-key")
+			testenv.Unset(t, "name-key")
 
 			awsssmProvider := newFakeAWSSSM(
 				t,

--- a/azkv/azkv_test.go
+++ b/azkv/azkv_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 )
 
@@ -620,7 +621,7 @@ func TestAZKVLoadConfiguredSecrets(t *testing.T) {
 			)
 
 			for key := range tt.wantValues {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 			}
 			if tt.existingKey != "" {
 				t.Setenv(tt.existingKey, tt.existingValue)
@@ -804,7 +805,7 @@ func TestAZKVLoadListsAllSecrets(t *testing.T) {
 			tt.setup(t, fake)
 
 			for key := range tt.wantValues {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 			}
 
 			provider := newTestAZKV(t, fake, false, false)

--- a/cmd/utils_additional_test.go
+++ b/cmd/utils_additional_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/sypl/es/v2"
 	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/sypl/v2/output"
@@ -208,14 +209,15 @@ func TestCommandArgsJSON(t *testing.T) {
 
 func TestLoadFromText(t *testing.T) {
 	tests := []struct {
-		name           string
-		format         string
-		data           string
-		key            string
-		wantValue      string
-		existingValue  string
-		shouldOverride bool
-		rawValue       bool
+		name            string
+		format          string
+		data            string
+		key             string
+		wantValue       string
+		existingValue   string
+		existingPresent bool
+		shouldOverride  bool
+		rawValue        bool
 	}{
 		{
 			name:      "happy path env",
@@ -232,12 +234,35 @@ func TestLoadFromText(t *testing.T) {
 			wantValue: "42",
 		},
 		{
-			name:          "edge case existing value is preserved without override",
-			format:        "env",
-			data:          "CONFIGURER_TEXT_COLLISION=loaded\n",
-			key:           "CONFIGURER_TEXT_COLLISION",
-			existingValue: "existing",
-			wantValue:     "existing",
+			name:            "edge case existing value is preserved without override",
+			format:          "env",
+			data:            "CONFIGURER_TEXT_COLLISION=loaded\n",
+			key:             "CONFIGURER_TEXT_COLLISION",
+			existingValue:   "existing",
+			existingPresent: true,
+			wantValue:       "existing",
+		},
+		{
+			// Regression for the config-precedence inversion: an embedded
+			// development config must not overwrite a variable the runtime
+			// injected as empty when the caller asked for no override.
+			name:            "edge case present but empty existing value is preserved",
+			format:          "env",
+			data:            "CONFIGURER_TEXT_EMPTY=loaded\n",
+			key:             "CONFIGURER_TEXT_EMPTY",
+			existingValue:   "",
+			existingPresent: true,
+			wantValue:       "",
+		},
+		{
+			name:            "edge case override replaces present but empty existing value",
+			format:          "env",
+			data:            "CONFIGURER_TEXT_EMPTY_OVERRIDE=loaded\n",
+			key:             "CONFIGURER_TEXT_EMPTY_OVERRIDE",
+			existingValue:   "",
+			existingPresent: true,
+			shouldOverride:  true,
+			wantValue:       "loaded",
 		},
 		{
 			name:           "edge case raw and override options retained by provider",
@@ -252,7 +277,7 @@ func TestLoadFromText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(tt.key, tt.existingValue)
+			testenv.SetPresence(t, tt.key, tt.existingValue, tt.existingPresent)
 
 			loadedProvider, err := LoadFromText(
 				tt.shouldOverride,
@@ -265,9 +290,38 @@ func TestLoadFromText(t *testing.T) {
 			require.NotNil(t, loadedProvider)
 			assert.Equal(t, tt.shouldOverride, loadedProvider.GetOverride())
 			assert.Equal(t, tt.rawValue, loadedProvider.GetRawValue())
-			assert.Equal(t, tt.wantValue, os.Getenv(tt.key))
+			testenv.RequireSet(t, tt.key, tt.wantValue)
 		})
 	}
+}
+
+// TestLoadFromTextMultipleKeysPrecedence reproduces the production incident
+// that motivated this regression suite: an embedded development config is
+// loaded with shouldOverride=false while the runtime has already injected the
+// real values. Every injected variable must survive — including one injected
+// as empty — while genuinely absent keys are still populated.
+func TestLoadFromTextMultipleKeysPrecedence(t *testing.T) {
+	const (
+		injected = "CONFIGURER_TEXT_MULTI_INJECTED"
+		blank    = "CONFIGURER_TEXT_MULTI_BLANK"
+		absent   = "CONFIGURER_TEXT_MULTI_ABSENT"
+	)
+
+	testenv.SetPresence(t, injected, "mongodb://prod-atlas:27017", true)
+	testenv.SetPresence(t, blank, "", true)
+	testenv.SetPresence(t, absent, "", false)
+
+	data := injected + "=mongodb://localhost:27017\n" +
+		blank + "=devDefault\n" +
+		absent + "=devOnly\n"
+
+	loadedProvider, err := LoadFromText(false, false, "env", data)
+	require.NoError(t, err)
+	require.NotNil(t, loadedProvider)
+
+	testenv.RequireSet(t, injected, "mongodb://prod-atlas:27017")
+	testenv.RequireSet(t, blank, "")
+	testenv.RequireSet(t, absent, "devOnly")
 }
 
 func TestLoadFromTextErrors(t *testing.T) {

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,80 @@
+// Copyright 2022 The configurer Authors. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// Package testenv provides helpers to put environment variables into a known
+// state during tests.
+//
+// Providers decide whether to overwrite a variable based on its PRESENCE, not
+// on whether it's empty, so tests must be able to say "absent" and "present but
+// empty" without ambiguity. Spelling "absent" as `t.Setenv(key, "")` says
+// "present and empty" instead, which is how an empty-value clobber bug once
+// survived the test suite.
+package testenv
+
+import (
+	"os"
+	"testing"
+)
+
+// Unset removes the given keys from the environment for the duration of the
+// test, restoring whatever was there before once the test finishes.
+//
+// t.Setenv runs first so the testing package registers its restore cleanup,
+// then the variable is genuinely removed.
+func Unset(tb testing.TB, keys ...string) {
+	tb.Helper()
+
+	for _, key := range keys {
+		tb.Setenv(key, "placeholder")
+
+		if err := os.Unsetenv(key); err != nil {
+			tb.Fatalf("unset %s: %v", key, err)
+		}
+
+		if _, present := os.LookupEnv(key); present {
+			tb.Fatalf("precondition: %s should be absent", key)
+		}
+	}
+}
+
+// Set makes the given key present with the given value (possibly empty) for the
+// duration of the test.
+func Set(tb testing.TB, key, value string) {
+	tb.Helper()
+
+	tb.Setenv(key, value)
+
+	if _, present := os.LookupEnv(key); !present {
+		tb.Fatalf("precondition: %s should be present", key)
+	}
+}
+
+// RequireSet asserts that key is still PRESENT in the environment and holds
+// want. os.Getenv alone cannot express this: it returns "" both for a variable
+// preserved as the empty string and for one that was removed outright.
+func RequireSet(tb testing.TB, key, want string) {
+	tb.Helper()
+
+	got, present := os.LookupEnv(key)
+	if !present {
+		tb.Fatalf("postcondition: %s should still be present, want %q", key, want)
+	}
+
+	if got != want {
+		tb.Fatalf("postcondition: %s = %q, want %q", key, got, want)
+	}
+}
+
+// SetPresence puts key into the requested state: present with value, or absent.
+func SetPresence(tb testing.TB, key, value string, present bool) {
+	tb.Helper()
+
+	if present {
+		Set(tb, key, value)
+
+		return
+	}
+
+	Unset(tb, key)
+}

--- a/k8ssecret/k8ssecret_test.go
+++ b/k8ssecret/k8ssecret_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 	"github.com/thalesfsp/configurer/provider"
 )
@@ -286,7 +287,7 @@ func TestK8sSecretLoadMounted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for key := range tt.want {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 			}
 
 			created, err := New(false, false, &Config{Path: tt.setup(t)})
@@ -473,7 +474,7 @@ func TestK8sSecretLoadAPI(t *testing.T) {
 			}
 
 			for key := range tt.want {
-				t.Setenv(key, "")
+				testenv.Unset(t, key)
 			}
 
 			created, err := New(false, false, config)
@@ -524,7 +525,7 @@ func TestK8sSecretLoadAPITLS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("K8S_TLS_KEY", "")
+			testenv.Unset(t, "K8S_TLS_KEY")
 
 			server, listener := newK8sSecretTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "Bearer api-token", r.Header.Get("Authorization"))

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -26,8 +26,13 @@ func anyMaxLevel(l *sypl.Sypl, target level.Level) bool {
 // ExportToEnvVar exports the given key and value to the environment.
 //
 // NOTE: If override is `true`, it'll override existing environment variables!
+//
+// NOTE: Precedence is decided by PRESENCE, not by emptiness. A variable that is
+// already set — even to the empty string — is an explicit choice by whoever set
+// it, so it's preserved unless override is `true`. This matches the semantics of
+// godotenv and of dotenv implementations at large.
 func ExportToEnvVar(p IProvider, key string, value interface{}) (string, error) {
-	fromOsEnvValue := os.Getenv(key)
+	fromOsEnvValue, isSetInOsEnv := os.LookupEnv(key)
 
 	// Should export to the environment.
 	finalValue := fmt.Sprintf("%v", value)
@@ -37,7 +42,7 @@ func ExportToEnvVar(p IProvider, key string, value interface{}) (string, error) 
 	}
 
 	// Should allow to don't overwrite existing environment variables.
-	if fromOsEnvValue != "" && !p.GetOverride() {
+	if isSetInOsEnv && !p.GetOverride() {
 		finalValue = fromOsEnvValue
 	}
 

--- a/provider/utils_test.go
+++ b/provider/utils_test.go
@@ -3,12 +3,12 @@ package provider
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thalesfsp/configurer/internal/logging"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 	"github.com/thalesfsp/sypl/v2"
 	"github.com/thalesfsp/sypl/v2/level"
@@ -147,16 +147,20 @@ func TestAnyMaxLevel(t *testing.T) {
 func TestExportToEnvVar(t *testing.T) {
 	const key = "CONFIGURER_PROVIDER_EXPORT_TEST"
 
+	// initialPresent distinguishes "variable absent from the environment" from
+	// "variable present and set to the empty string". Both used to be spelled
+	// initialValue: "", which is why the clobber went unnoticed.
 	tests := []struct {
-		name         string
-		key          string
-		initialValue string
-		value        interface{}
-		override     bool
-		rawValue     bool
-		logLevels    []level.Level
-		want         string
-		wantErr      bool
+		name           string
+		key            string
+		initialValue   string
+		initialPresent bool
+		value          interface{}
+		override       bool
+		rawValue       bool
+		logLevels      []level.Level
+		want           string
+		wantErr        bool
 	}{
 		{
 			name:  "exports new string",
@@ -165,19 +169,21 @@ func TestExportToEnvVar(t *testing.T) {
 			want:  "loaded",
 		},
 		{
-			name:         "existing environment value wins",
-			key:          key,
-			initialValue: "existing",
-			value:        "loaded",
-			want:         "existing",
+			name:           "existing environment value wins",
+			key:            key,
+			initialValue:   "existing",
+			initialPresent: true,
+			value:          "loaded",
+			want:           "existing",
 		},
 		{
-			name:         "override replaces existing environment value",
-			key:          key,
-			initialValue: "existing",
-			value:        "loaded",
-			override:     true,
-			want:         "loaded",
+			name:           "override replaces existing environment value",
+			key:            key,
+			initialValue:   "existing",
+			initialPresent: true,
+			value:          "loaded",
+			override:       true,
+			want:           "loaded",
 		},
 		{
 			name:  "empty incoming value remains empty",
@@ -186,11 +192,25 @@ func TestExportToEnvVar(t *testing.T) {
 			want:  "",
 		},
 		{
-			name:         "empty existing value does not block export",
-			key:          key,
-			initialValue: "",
-			value:        "loaded",
-			want:         "loaded",
+			// Regression: a variable that is SET to the empty string is still
+			// set, so it must win when override is off. The previous suite
+			// asserted the opposite ("empty existing value does not block
+			// export"), encoding the very bug it should have caught.
+			name:           "present but empty existing value is preserved",
+			key:            key,
+			initialValue:   "",
+			initialPresent: true,
+			value:          "loaded",
+			want:           "",
+		},
+		{
+			name:           "override replaces present but empty existing value",
+			key:            key,
+			initialValue:   "",
+			initialPresent: true,
+			value:          "loaded",
+			override:       true,
+			want:           "loaded",
 		},
 		{
 			name:  "special characters and multiline remain unquoted",
@@ -204,6 +224,17 @@ func TestExportToEnvVar(t *testing.T) {
 			value:    "pa$$ word=\"quoted\"\nnext=line",
 			rawValue: true,
 			want:     "\"pa$$ word=\\\"quoted\\\"\\nnext=line\"",
+		},
+		{
+			// The preserved environment value is returned byte for byte: raw
+			// formatting only ever applies to the provider-sourced value.
+			name:           "raw formatting is not applied to a preserved value",
+			key:            key,
+			initialValue:   "existing",
+			initialPresent: true,
+			value:          "loaded",
+			rawValue:       true,
+			want:           "existing",
 		},
 		{
 			name:      "debug logging branch",
@@ -232,7 +263,7 @@ func TestExportToEnvVar(t *testing.T) {
 			t.Setenv(shared.LevelEnvVar, "")
 
 			if tt.key != "INVALID=KEY" {
-				t.Setenv(tt.key, tt.initialValue)
+				testenv.SetPresence(t, tt.key, tt.initialValue, tt.initialPresent)
 			}
 
 			p := &exportTestProvider{
@@ -256,7 +287,7 @@ func TestExportToEnvVar(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
-			assert.Equal(t, tt.want, os.Getenv(tt.key))
+			testenv.RequireSet(t, tt.key, tt.want)
 		})
 	}
 }

--- a/vault/vault_unit_test.go
+++ b/vault/vault_unit_test.go
@@ -13,6 +13,7 @@ import (
 	api "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/configurer/internal/testenv"
 	"github.com/thalesfsp/configurer/option"
 )
 
@@ -63,7 +64,7 @@ func cleanVaultEnvironment(t *testing.T) {
 		api.EnvVaultProxyAddr,
 		api.EnvVaultDisableRedirects,
 	} {
-		t.Setenv(key, "")
+		testenv.Unset(t, key)
 	}
 }
 
@@ -516,8 +517,8 @@ func TestVaultLoad(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cleanVaultEnvironment(t)
-			t.Setenv("TEST_DB_USER", "")
-			t.Setenv("TEST_PORT", "")
+			testenv.Unset(t, "TEST_DB_USER")
+			testenv.Unset(t, "TEST_PORT")
 			t.Setenv("VAULT_EXISTING", "from-environment")
 
 			server, requests, callCount := newVaultTestServer(t, tt.statusCode, tt.responseBody)


### PR DESCRIPTION
## TL;DR

Env var precedence was decided by **emptiness** instead of **presence**. A variable that is already set — but set to `""` — was silently overwritten by the provider value even when the caller asked for `override=false`. `provider.ExportToEnvVar` is the single env-write site for the whole module, so this applied to **every** provider.

**Please read the blast-radius section before releasing.** This is a real behavior change.

## Problem framing

| | |
|---|---|
| **Is this a SecOps problem?** | No — correctness. Config precedence inversion. It can *look* like one when a production secret gets replaced by a development default. |
| **What does this fix, fix?** | `override=false` now actually means "don't touch variables that are already set", including ones set to the empty string. |
| **Why is it needed?** | Silently replacing injected runtime config with provider/embedded values causes services to boot against the wrong backend. |
| **What is it blocking?** | Nothing is gated on it. |

## Context: the originally reported bug is already fixed

The report that started this was `cmd.LoadFromText` in **v1.3.35** doing an unconditional `os.Setenv` in a loop, ignoring `shouldOverride` — an embedded `development.env` clobbered an injected production `MONGODB_HOST` on Fly.io, so the service dialed `localhost` and crash-looped.

That loop was already replaced with `provider.ExportToEnvVar` in `d750737`, first released in **v1.4.0**. Consumers still on v1.3.x fix it by upgrading to ≥ v1.4.0. No code change needed for that part.

## What is still broken (and what this PR fixes)

`provider/utils.go`:

```go
fromOsEnvValue := os.Getenv(key)
...
if fromOsEnvValue != "" && !p.GetOverride() {   // <-- emptiness, not presence
	finalValue = fromOsEnvValue
}
```

`os.Getenv` returns `""` for both "absent" and "present but empty", so a present-but-empty variable took the export branch.

Reproduced on unmodified `origin/main`:

```
t.Setenv("K", "")                                        // K is PRESENT, value ""
LoadFromText(false, false, "env", "K=fromEmbeddedDevConfig")
// => K == "fromEmbeddedDevConfig"   (shouldOverride was false)
```

The fix gates on presence via `os.LookupEnv`. This matches **godotenv** — which configurer already depends on and which uses presence (`if !currentEnv[key] || overload`) — and the documented intent that current env var values take precedence.

### Before / after

| Initial state of `KEY` | `override` | Before | After |
|---|---|---|---|
| absent | false | provider value | provider value (unchanged) |
| present, `"existing"` | false | `"existing"` | `"existing"` (unchanged) |
| **present, `""`** | **false** | **provider value** | **`""` preserved** |
| present, `""` | true | provider value | provider value (unchanged) |
| present, `"existing"` | true | provider value | provider value (unchanged) |

Only the bolded row changes.

## Sibling audit

- `provider/utils.go:44` is the **only** env-write site in the module. All ten load-capable providers (vault, awssm, awsssm, azkv, gcpsm, doppler, k8ssecret, onepassword, dotenv, noop) route through it, so one fix covers them all.
- `dotenv.New(override, ...)` just forwards `override` into `provider.New`, and `DotEnv.Load` exports through the same helper — consistent with the fix, no change needed.
- `noop/noop.go` only *reads* `os.Environ()`.
- `util.SetEnv` (`util/dump.go`) has a related but **distinct** contract: hydrating a struct from `env` tags, it treats `os.Getenv(tag) == ""` as "not set". Deliberately **not** changed here — making empty meaningful there would turn `PORT=""` into a parse error for int fields and would change how `default` tags interact with empty strings. That needs its own policy decision. Follow-up noted below.

## Tests: why the old suite missed this

The suite could not express the distinction. It spelled "absent" as `t.Setenv(key, "")` — which actually means "present and empty" — and one case asserted the bug outright:

```go
name:         "empty existing value does not block export",
initialValue: "",
value:        "loaded",
want:         "loaded",     // encoded the defect as expected behavior
```

Changes:

- **`internal/testenv`** (new) — `Set`, `Unset`, `SetPresence`, `RequireSet`. Tests now state presence explicitly and assert preconditions, so absent and present-empty can never be confused again.
- Corrected that case to `"present but empty existing value is preserved"`, and added: override-replaces-present-empty, and raw-formatting-is-not-applied-to-a-preserved-value.
- `TestLoadFromTextMultipleKeysPrecedence` reproduces the production incident end to end: injected value survives, injected-empty survives, genuinely absent key is populated.
- Postconditions use `LookupEnv` (via `testenv.RequireSet`), so "preserved as empty" is distinguishable from "deleted" — `os.Getenv` alone returns `""` for both.
- The five provider test packages that used `t.Setenv(key, "")` purely to neutralize ambient env now use `testenv.Unset`, which is what they always meant.

**No test was deleted, skipped, or loosened.** Evidence that the provider-package edits are semantics-neutral: those five packages pass under **both** the old and the new production code — only the three new regression cases discriminate.

### Negative control

Fix reverted in place, tests re-run — failing for exactly the right reason, and only these three:

```
provider  TestExportToEnvVar/present_but_empty_existing_value_is_preserved
          postcondition: CONFIGURER_PROVIDER_EXPORT_TEST = "loaded", want ""
cmd       TestLoadFromText/edge_case_present_but_empty_existing_value_is_preserved
          postcondition: CONFIGURER_TEXT_EMPTY = "loaded", want ""
cmd       TestLoadFromTextMultipleKeysPrecedence
          postcondition: CONFIGURER_TEXT_MULTI_BLANK = "devDefault", want ""
```

Fix restored → all green.

## Blast radius — read before releasing

A consumer changes behavior only if **all three** hold: `override=false`, the variable is present with value `""`, and a provider supplies that key.

At-risk patterns: `docker run -e KEY=`, Kubernetes `env: [{name: KEY, value: ""}]`, CI templates that declare every variable empty, `.env` placeholders like `KEY=`, and sequential provider loads where an earlier provider produced an empty value. Those deployments will now keep the empty value instead of being filled in, which can surface as a startup failure.

Suggested release: **minor** (not a patch) purely for operational visibility, since it touches every provider. It is technically a bug fix against the documented contract — `Provider.Override` says "existing environment variables", not "existing non-empty ones" — so a major bump would overstate it. Final call is the maintainer's. Migration note is in `CHANGELOG.md` under `[Unreleased]`.

One knock-on worth knowing: `ExportToStruct` → `util.SetEnv` still treats present-empty as absent, so a preserved empty value will hydrate a struct field with its `default`/zero rather than the empty string. Pre-existing, unchanged by this PR, and tracked as the follow-up above.

## Verification (local, before push)

- `go build ./...` — clean
- `go vet ./...` — clean
- `VENDOR_ENVIRONMENT=testing go test -short -race -cover ./...` — all packages pass; `provider` at 100% coverage
- `golangci-lint run -c .golangci.yml` with **v2.5.0**, the exact CI pin (not the newer local build) — `0 issues`

`gofmt -l` reports `awsssm/awsssm_test.go`, which is pre-existing on `main` and untouched here.
